### PR TITLE
Use DOUBLE_LEFT_CURLY_BRACE scope expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ angular_xss [![Build Status](https://travis-ci.org/makandra/angular_xss.png?bran
 
 When rendering AngularJS templates with a server-side templating engine like ERB or Haml it is easy to introduce XSS vulnerabilities. These vulnerabilities are enabled by AngularJS evaluating user-provided strings containing interpolation symbols (default symbols are `{{` and `}}`).
 
-This gem patches ERB/rails_xss and Haml so Angular interpolation symbols are auto-escaped in unsafe strings. And by auto-escaped we mean replacing `{{` with ` { { `. To leave AngularJS interpolation marks unescaped, mark the string as `html_safe`.
+This gem patches ERB/rails_xss and Haml so Angular interpolation symbols are auto-escaped in unsafe strings. And by auto-escaped we mean replacing `{{` with `{{ $root.DOUBLE_LEFT_CURLY_BRACE }}`. To leave AngularJS interpolation marks unescaped, mark the string as `html_safe`.
 
 **This is an unsatisfactory hack.** A better solution is very much desired, but is not possible without some changes in AngularJS. See the [related AngularJS issue](https://github.com/angular/angular.js/issues/5601).
 

--- a/lib/angular_xss/escaper.rb
+++ b/lib/angular_xss/escaper.rb
@@ -23,7 +23,7 @@ module AngularXss
       if disabled?
         string
       else
-        string.gsub('{{', ' { { ')
+        string.to_s.gsub('{{'.freeze, '{{ $root.DOUBLE_LEFT_CURLY_BRACE }}'.freeze)
       end
     end
 
@@ -41,4 +41,3 @@ module AngularXss
 
   end
 end
-

--- a/spec/shared/support/engine_preventing_angular_xss.rb
+++ b/spec/shared/support/engine_preventing_angular_xss.rb
@@ -6,12 +6,12 @@ shared_examples_for 'engine preventing Angular XSS' do
 
   it 'escapes Angular interpolation marks in unsafe strings' do
     html.should_not include('{{unsafe}}')
-    html.should include(' { { unsafe}}')
+    html.should include('{{ $root.DOUBLE_LEFT_CURLY_BRACE }}unsafe}}')
   end
 
   it 'recognizes the many ways to express an opening curly brace in HTML' do
 
-    html.should include(" { { unsafe}}")
+    html.should include("{{ $root.DOUBLE_LEFT_CURLY_BRACE }}unsafe}}")
     html.should_not include("{{unsafe}}")
 
     braces = [
@@ -37,7 +37,7 @@ shared_examples_for 'engine preventing Angular XSS' do
 
   it 'does not escape Angular interpolation marks in safe strings' do
     html.should include("{{safe}}")
-    html.should_not include(" { { safe}}")
+    html.should_not include("{{ $root.DOUBLE_LEFT_CURLY_BRACE }}safe}}")
   end
 
   it 'does not escape Angular interpolation marks in a block where AngularXSS is disabled' do
@@ -47,7 +47,7 @@ shared_examples_for 'engine preventing Angular XSS' do
     end
 
     result.should include('{{unsafe}}')
-    result.should_not include(' { { unsafe}}')
+    result.should_not include('{{ $root.DOUBLE_LEFT_CURLY_BRACE }}unsafe}}')
   end
 
   it 'does escape Angular interpolation marks after the block where AngularXSS is disabled' do
@@ -55,7 +55,7 @@ shared_examples_for 'engine preventing Angular XSS' do
     end
     result = html
 
-    result.should include(' { { unsafe}}')
+    result.should include('{{ $root.DOUBLE_LEFT_CURLY_BRACE }}unsafe}}')
     result.should_not include('{{unsafe}}')
   end
 
@@ -68,7 +68,7 @@ shared_examples_for 'engine preventing Angular XSS' do
       end
     }.should raise_error(SomeException)
 
-    html.should include(' { { unsafe}}')
+    html.should include('{{ $root.DOUBLE_LEFT_CURLY_BRACE }}unsafe}}')
     html.should_not include('{{unsafe}}')
   end
 


### PR DESCRIPTION
Using the replacement `{{ $root.DOUBLE_LEFT_CURLY_BRACE }} `` for the
string `{{` in the escaping process, we can escape an interpolated
expression while retaining the original look at the cost of actually
interpolating something in the Angular application.

See the following commits for details:
- https://github.com/opf/rails-angular-xss/commit/c307fb53c30409380e39ca802fab3f7f6d5a7ca4
- https://github.com/opf/rails-angular-xss/commit/a45267d53d32610bad01f903e9f1b49a81b7c37b

Additionally, prevent mutating lookup & replace escape strings

Our fork includes some changes found in their updated project at https://github.com/opf/rails-angular-xss. We opted to fork the former project which supports Rails 3.2, Rails 4.2, and HAML, while the latter requires Rails 5.x and offers no HAML support.