### PR TITLE
Prepare AngularXSS for Rails 7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,16 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - ruby: 2.3.5
-          gemfile: Gemfile.rails-3.2
-        - ruby: 2.3.5
-          gemfile: Gemfile.rails-4.2.haml-4
-        - ruby: 2.3.5
-          gemfile: Gemfile.rails-4.2.haml-5
-        - ruby: 2.3.5
-          gemfile: Gemfile.rails-5.1.haml-4
-        - ruby: 2.3.5
-          gemfile: Gemfile.rails-5.1.haml-5
         - ruby: 2.7.2
           gemfile: Gemfile.rails-5.1.haml-4
         - ruby: 2.7.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - ruby: 2.5.9
+          gemfile: Gemfile.rails-3.2
+        - ruby: 2.5.9
+          gemfile: Gemfile.rails-4.2.haml-4
+        - ruby: 2.5.9
+          gemfile: Gemfile.rails-4.2.haml-5
+        - ruby: 2.5.9
+          gemfile: Gemfile.rails-5.1.haml-4
+        - ruby: 2.5.9
+          gemfile: Gemfile.rails-5.1.haml-5
+
         - ruby: 2.7.2
           gemfile: Gemfile.rails-5.1.haml-4
         - ruby: 2.7.2
           gemfile: Gemfile.rails-5.1.haml-5
         - ruby: 2.7.2
           gemfile: Gemfile.rails-6.1.haml-5
+        - ruby: 2.7.2
+          gemfile: Gemfile.rails-7.0.haml-5
+
         - ruby: 3.0.1
           gemfile: Gemfile.rails-5.1.haml-4
         - ruby: 3.0.1
           gemfile: Gemfile.rails-5.1.haml-5
         - ruby: 3.0.1
           gemfile: Gemfile.rails-6.1.haml-5
+        - ruby: 3.0.1
+          gemfile: Gemfile.rails-7.0.haml-5
     env:
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:

--- a/Gemfile.rails-7.0.haml-5
+++ b/Gemfile.rails-7.0.haml-5
@@ -1,0 +1,8 @@
+source 'http://rubygems.org'
+
+gem 'actionpack', '~>7.0'
+gem 'rspec'
+gem 'haml', '~> 5'
+gem 'angular_xss', :path => '.'
+gem 'gemika'
+gem 'rake'

--- a/Gemfile.rails-7.0.haml-5.lock
+++ b/Gemfile.rails-7.0.haml-5.lock
@@ -1,0 +1,86 @@
+PATH
+  remote: .
+  specs:
+    angular_xss (0.4.0)
+      activesupport
+      haml (>= 3.1.5)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    actionpack (7.0.0)
+      actionview (= 7.0.0)
+      activesupport (= 7.0.0)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionview (7.0.0)
+      activesupport (= 7.0.0)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activesupport (7.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    builder (3.2.4)
+    concurrent-ruby (1.1.9)
+    crass (1.0.6)
+    diff-lcs (1.4.4)
+    erubi (1.10.0)
+    gemika (0.6.1)
+    haml (5.2.2)
+      temple (>= 0.8.0)
+      tilt
+    i18n (1.8.11)
+      concurrent-ruby (~> 1.0)
+    loofah (2.13.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    minitest (5.15.0)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
+    racc (1.6.0)
+    rack (2.2.3)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.2)
+      loofah (~> 2.3)
+    rake (13.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.3)
+    temple (0.8.2)
+    tilt (2.0.10)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  actionpack (~> 7.0)
+  angular_xss!
+  gemika
+  haml (~> 5)
+  rake
+  rspec
+
+BUNDLED WITH
+   2.2.26

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Development
 
 - Fork the repository.
 - Push your changes with specs. There is a Rails 3 test application in `spec/app_root` if you need to test integration with a live Rails app.
+- You may run single tests with a specified Rails version via `BUNDLE_GEMFILE=Gemfile.rails-7.0.haml-5 bundle exec rspec ./spec/angular_xss`
 - Send a pull request.
 
 

--- a/lib/angular_xss/safe_buffer.rb
+++ b/lib/angular_xss/safe_buffer.rb
@@ -1,20 +1,44 @@
+##
+# Monkey patch ActiveSupport::SafeBuffer to escape double braces from Angular
+#
+# Link to the original implementation without Angular XSS escaping:
+# https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/core_ext/string/output_safety.rb#L295
+#
 ActiveSupport::SafeBuffer.class_eval do
 
-  if private_method_defined? :html_escape_interpolated_argument
+  html_escape = :html_escape_interpolated_argument
+
+  if private_method_defined?(html_escape) || # Rails < 6.1
+    private_method_defined?(:"explicit_#{html_escape}") # Rails >= 6.1
 
     private
 
-    def html_escape_interpolated_argument_with_angular_xss(arg)
-      if arg.html_safe?
+    def explicit_html_escape_interpolated_argument_with_angular_xss(arg)
+      if !html_safe? || arg.html_safe?
         arg
       else
-        html_escape_interpolated_argument_without_angular_xss(AngularXss::Escaper.escape(arg))
+        explicit_html_escape_interpolated_argument_without_angular_xss(AngularXss::Escaper.escape(arg))
       end
     end
 
-    alias_method :html_escape_interpolated_argument_without_angular_xss, :html_escape_interpolated_argument
-    alias_method :html_escape_interpolated_argument, :html_escape_interpolated_argument_with_angular_xss
+    if private_method_defined?(html_escape)
+      alias_method :"explicit_#{html_escape}_without_angular_xss", html_escape
+      alias_method html_escape, :"explicit_#{html_escape}_with_angular_xss"
+    elsif private_method_defined?(:"explicit_#{html_escape}")
+      alias_method :"explicit_#{html_escape}_without_angular_xss", :"explicit_#{html_escape}"
+      alias_method :"explicit_#{html_escape}", :"explicit_#{html_escape}_with_angular_xss"
+    end
 
+    if private_method_defined?(:"implicit_#{html_escape}")
+      def implicit_html_escape_interpolated_argument_with_angular_xss(arg)
+        if !html_safe? || arg.html_safe?
+          arg
+        else
+          implicit_html_escape_interpolated_argument_without_angular_xss(AngularXss::Escaper.escape(arg))
+        end
+      end
+      alias_method :"implicit_#{html_escape}_without_angular_xss", :"implicit_#{html_escape}"
+      alias_method :"implicit_#{html_escape}", :"implicit_#{html_escape}_with_angular_xss"
+    end
   end
-
 end


### PR DESCRIPTION
Some changes were required as Rails 7 defines separate methods für explicit and implicit string conversion:
* 6.1: https://github.com/rails/rails/blob/v6.1.4.4/activesupport/lib/active_support/core_ext/string/output_safety.rb
* 7.0: https://github.com/rails/rails/blob/v7.0.0/activesupport/lib/active_support/core_ext/string/output_safety.rb
The CHANGELOG however does not say anything about it.